### PR TITLE
View Once more info, support view once audio messages, and fix race condition that results in not showing view once messages if the chat is open.

### DIFF
--- a/core/interception.js
+++ b/core/interception.js
@@ -463,7 +463,7 @@ NodeHandler.onMessageNodeReceived = async function(currentNode, messageNodes, is
     return isAllowed;
 }
 
-NodeHandler.onE2EMessageNodeReceived = function(currentNode, message, isMultiDevice, encNodes, messageNodes)
+NodeHandler.onE2EMessageNodeReceived = async function(currentNode, message, isMultiDevice, encNodes, messageNodes)
 {
     var isAllowed = true;
     var remoteJid = null;
@@ -485,7 +485,7 @@ NodeHandler.onE2EMessageNodeReceived = function(currentNode, message, isMultiDev
     }
 
     var isRevokeMessage = NodeHandler.checkForMessageDeletionNode(message, messageId, remoteJid);
-    interceptViewOnceMessages(encNodes, messageId);
+    await interceptViewOnceMessages(encNodes, messageId);
 
     if (!saveDeletedMsgsHookEnabled)
     {
@@ -534,66 +534,92 @@ NodeHandler.manipulateReceivedNode = async function (node)
     return node;
 }
 
-async function interceptViewOnceMessages(encNodes, messageId) {
-    if (encNodes[0].viewOnceMessageV2 !== null) {
+async function interceptViewOnceMessages(encNodes, messageId) 
+{
+    if (encNodes[0].viewOnceMessageV2 !== null || encNodes[0].viewOnceMessageV2Extension !== null) 
+    {
         var retrievedMsg = {};
         var type = "";
-        if (encNodes[0].viewOnceMessageV2.message.imageMessage !== null) {
-            retrievedMsg = encNodes[0].viewOnceMessageV2.message.imageMessage;
-            type = "image";
+        if(encNodes[0].viewOnceMessageV2 !== null)
+        {
+            if (encNodes[0].viewOnceMessageV2.message.imageMessage !== null) 
+            {
+                retrievedMsg = encNodes[0].viewOnceMessageV2.message.imageMessage;
+                type = "image";
+            }
+            else if (encNodes[0].viewOnceMessageV2.message.videoMessage !== null) 
+            {
+                retrievedMsg = encNodes[0].viewOnceMessageV2.message.videoMessage;
+                type = "video";
+            }
+            else
+            {
+                throw new Error("Unknown viewOnceMessageV2 type");
+            }
         }
-        else if (encNodes[0].viewOnceMessageV2.message.videoMessage !== null) {
-            retrievedMsg = encNodes[0].viewOnceMessageV2.message.videoMessage;
-            type = "video";
+        else if (encNodes[0].viewOnceMessageV2Extension?.message?.audioMessage !== null) 
+        {
+            retrievedMsg = encNodes[0].viewOnceMessageV2Extension.message.audioMessage;
+            type = "audio";
         }
-
-        else {
-            throw new Error("Unknown viewOnceMessageV2 type");
+        else 
+        {
+            throw new Error("Unknown viewOnceMessageV2 or viewOnceMessageV2Extension type");
         }
-
         const mediaKeyEncoded = btoa(String.fromCharCode.apply(null, retrievedMsg.mediaKey));
         const encodedencFileHash = btoa(String.fromCharCode.apply(null, retrievedMsg.fileEncSha256));
         const encodedfileSha256 = btoa(String.fromCharCode.apply(null, retrievedMsg.fileSha256));
+        
+        if(window.WhatsAppAPI !== undefined)
+        {
+            const decryptedData = await WhatsAppAPI.downloadManager.downloadAndMaybeDecrypt({
+                directPath: retrievedMsg.directPath,
+                encFilehash: encodedencFileHash, filehash: encodedfileSha256, mediaKey: mediaKeyEncoded,
+                type: type, signal: (new AbortController).signal
+            });
 
-        const decryptedData = await WhatsAppAPI.downloadManager.downloadAndMaybeDecrypt({
-            directPath: retrievedMsg.directPath,
-            encFilehash: encodedencFileHash, filehash: encodedfileSha256, mediaKey: mediaKeyEncoded,
-            type: type, signal: (new AbortController).signal
-        });
-
-        body = arrayBufferToBase64(decryptedData);
-        dataURI = "data:" + retrievedMsg.mimetype + ";base64," + body;
-        // store in indexedDB called "view-once" messageID and dataURI 
-        var viewOnceDBOpenRequest = indexedDB.open("viewOnce", 2);
-        viewOnceDBOpenRequest.onupgradeneeded = function (event) {
-            const db = event.target.result;
-            var store = db.createObjectStore('msgs', { keyPath: 'id' });
-            if (WAdebugMode) {
-                console.log('WhatsIncognito: Deleted messages database generated');
-            }
-            store.createIndex("id_index", "id");
-        };
-        viewOnceDBOpenRequest.onerror = function (e) {
-            console.error("WhatsIncognito: Error opening database");
-            console.error("Error", viewOnceDBOpenRequest);
-            console.error(e);
-        };
-        viewOnceDBOpenRequest.onsuccess = () => {
-            var viewOnceDB = viewOnceDBOpenRequest.result;
-            var viewOnceTranscation = viewOnceDB.transaction('msgs', "readwrite");
-            var viewOnceRequest = viewOnceTranscation.objectStore("msgs").add({ id: messageId, dataURI: dataURI });
-            viewOnceRequest.onerror = (e) => {
-                if (viewOnceRequest.error.name == "ConstraintError") {
-                    if (WAdebugMode) {
-                        console.log("WhatsIncognito: Not saving message becuase the message ID already exists");
-                    }
+            body = arrayBufferToBase64(decryptedData);
+            dataURI = "data:" + retrievedMsg.mimetype + ";base64," + body;
+            // store in indexedDB called "view-once" messageID and dataURI 
+            var viewOnceDBOpenRequest = indexedDB.open("viewOnce", 2);
+            viewOnceDBOpenRequest.onupgradeneeded = function (event) {
+                const db = event.target.result;
+                var store = db.createObjectStore('msgs', { keyPath: 'id' });
+                if (WAdebugMode) {
+                    console.log('WhatsIncognito: Deleted messages database generated');
                 }
-
-                else {
-                    console.warn("WhatsIncognito: Unexpected error saving deleted message");
-                }
+                store.createIndex("id_index", "id");
             };
-        };
+            viewOnceDBOpenRequest.onerror = function (e) {
+                console.error("WhatsIncognito: Error opening database");
+                console.error("Error", viewOnceDBOpenRequest);
+                console.error(e);
+            };
+            viewOnceDBOpenRequest.onsuccess = () => {
+                var viewOnceDB = viewOnceDBOpenRequest.result;
+                var viewOnceTranscation = viewOnceDB.transaction('msgs', "readwrite");
+                var viewOnceRequest = viewOnceTranscation.objectStore("msgs").add({ id: messageId, dataURI: dataURI });
+                viewOnceRequest.onerror = (e) => {
+                    if (viewOnceRequest.error.name == "ConstraintError") {
+                        if (WAdebugMode) {
+                            console.log("WhatsIncognito: Not saving message becuase the message ID already exists");
+                        }
+                    }
+
+                    else {
+                        console.warn("WhatsIncognito: Unexpected error saving deleted message");
+                    }
+                };
+            };
+        }
+        else
+        {
+            // retry in 5 seconds
+            // don't know why it's 5 seconds, but that's what is done for decrypting deleted messages 
+            setTimeout(function(){
+                interceptViewOnceMessages(encNodes, messageId)
+            }, 5000);
+        }
     }
 }
 

--- a/core/interception.js
+++ b/core/interception.js
@@ -580,6 +580,7 @@ async function interceptViewOnceMessages(encNodes, messageId)
 
             body = arrayBufferToBase64(decryptedData);
             dataURI = "data:" + retrievedMsg.mimetype + ";base64," + body;
+            var caption = retrievedMsg.caption;
             // store in indexedDB called "view-once" messageID and dataURI 
             var viewOnceDBOpenRequest = indexedDB.open("viewOnce", 2);
             viewOnceDBOpenRequest.onupgradeneeded = function (event) {
@@ -598,7 +599,7 @@ async function interceptViewOnceMessages(encNodes, messageId)
             viewOnceDBOpenRequest.onsuccess = () => {
                 var viewOnceDB = viewOnceDBOpenRequest.result;
                 var viewOnceTranscation = viewOnceDB.transaction('msgs', "readwrite");
-                var viewOnceRequest = viewOnceTranscation.objectStore("msgs").add({ id: messageId, dataURI: dataURI });
+                var viewOnceRequest = viewOnceTranscation.objectStore("msgs").add({ id: messageId, dataURI: dataURI, caption});
                 viewOnceRequest.onerror = (e) => {
                     if (viewOnceRequest.error.name == "ConstraintError") {
                         if (WAdebugMode) {

--- a/core/ui.js
+++ b/core/ui.js
@@ -666,6 +666,23 @@ function restoreViewOnceMessageIfNeeded(messageNode, msgID)
                         // append the video to the viewOnceExplanation
                         viewOnceExplanation.appendChild(video);
                     }
+                    // add a learn more link below that opens a sweetalert
+                    var learnMore = document.createElement("a");
+                    learnMore.href = "#";
+                    learnMore.innerHTML = "Sent as view once: Learn more";
+                    learnMore.addEventListener("click", function () {
+                        Swal.fire({
+                            title: "View-once message",
+                            html: 'This message was sent as a view-once. \
+                            <br><br> Note that the recipient\'s device will show this as unopened \
+                            <br><br> You can view this message multiple times and screenshot, and the recipient will not be notified. ',
+                            icon: "info",
+                            width: 600,
+                            confirmButtonColor: "#000",
+                            confirmButtonText: "Got it",
+                        });
+                    });
+                    viewOnceExplanation.appendChild(learnMore);
                 }
             });
         };

--- a/core/ui.js
+++ b/core/ui.js
@@ -674,6 +674,17 @@ function restoreViewOnceMessageIfNeeded(messageNode, msgID)
                         // append the audio to the viewOnceExplanation
                         viewOnceExplanation.appendChild(audio);
                     }
+
+                    // check if there is a caption stored and render it
+                    if(value.caption != null){
+                        var textSpan = document.createElement("span");
+                        var textSpanStyle = "font-style: normal; color: rgba(241, 241, 242, 0.95); margin-top: 10px; margin-bottom: 10px;";
+                        textSpan.style.cssText = textSpanStyle;
+                        textSpan.className = "copyable-text selectable-text";
+                        textSpan.textContent = value.caption;
+                        viewOnceExplanation.appendChild(textSpan);
+                    }
+
                     // add a learn more link below that opens a sweetalert
                     var learnMore = document.createElement("a");
                     // give it the class of incognito-view-once-learn-more so styles can be applied

--- a/core/ui.js
+++ b/core/ui.js
@@ -665,9 +665,19 @@ function restoreViewOnceMessageIfNeeded(messageNode, msgID)
                         video.src = value.dataURI;
                         // append the video to the viewOnceExplanation
                         viewOnceExplanation.appendChild(video);
+                    } else if (value.dataURI.startsWith("data:audio")) {
+                        // create an audio element
+                        var audio = document.createElement("audio");
+                        // set the controls to true
+                        audio.controls = true;
+                        audio.src = value.dataURI;
+                        // append the audio to the viewOnceExplanation
+                        viewOnceExplanation.appendChild(audio);
                     }
                     // add a learn more link below that opens a sweetalert
                     var learnMore = document.createElement("a");
+                    // give it the class of incognito-view-once-learn-more so styles can be applied
+                    learnMore.className = "incognito-view-once-learn-more";
                     learnMore.href = "#";
                     learnMore.innerHTML = "Sent as view once: Learn more";
                     learnMore.addEventListener("click", function () {

--- a/styles.css
+++ b/styles.css
@@ -443,3 +443,7 @@ input[type=number]::-webkit-inner-spin-button {
 #status-download-fail-button{
   width: 100px;
 }
+
+.incognito-view-once-learn-more{
+  display: block;
+}


### PR DESCRIPTION
### View Once more info
![image](https://github.com/tomer8007/whatsapp-web-incognito/assets/74068072/7925f807-194e-438e-b7d0-8761ffa50afc)
(this example uses a photo, but it works for videos and audio messages too)
When clicked:
![image](https://github.com/tomer8007/whatsapp-web-incognito/assets/74068072/572006be-ef03-4c1b-9878-f2adaad02240)
I am unsure if that is worded well, can you suggest what it should be changed to?

### View once audio messages
![image](https://github.com/tomer8007/whatsapp-web-incognito/assets/74068072/662d7949-a2d6-46e8-811e-a23922d9f106)
As this uses the default audio element, it can be downloaded or have the playback speed changed in my browser (MS Edge 120.0.2210.91) 

### Race condition fix
I don't know much about how JS handles promises, async etc in the event loop, but my fix (interception.js 466 and 488) seems to ensure that WhatsApp doesn't try to render the view once until it has been written to the IndexedDB. 

I can tell this fix is a bad idea, but I don't know of any other way of doing this, so please can you help me modify this to make it work.

There's a small issue wherein if the view once is sent while the webapp is closed, and then the user opens it and within 5 seconds of it opening views the chat, it will not change anything and the default UI (non-extension) will show. However, this issue is also present in the deleted messages feature, where messages don't get highlighted in this case.