### PR TITLE
Last seen and typing updates changes

### DIFF
--- a/core/injected_ui.js
+++ b/core/injected_ui.js
@@ -7,6 +7,11 @@ document.addEventListener('onMainUIReady', function (e)
     setTimeout(exposeWhatsAppAPI, 100);
 });
 
+document.addEventListener('onPresenceOptionTicked', function (e)
+{
+    WhatsAppAPI.sendPresenceStatusProtocol({name:"",status:"unavailable"})
+});
+
 document.addEventListener('onIncognitoOptionsOpened', function (e)
 {
     var drop = document.getElementsByClassName("drop")[0];

--- a/core/injected_ui.js
+++ b/core/injected_ui.js
@@ -12,6 +12,12 @@ document.addEventListener('onPresenceOptionTicked', function (e)
     WhatsAppAPI.sendPresenceStatusProtocol({name:"",status:"unavailable"})
 });
 
+document.addEventListener('onPresenceOptionUnticked', function (e)
+{
+    WhatsAppAPI.sendPresenceStatusProtocol({name:"",status:"available"})
+});
+
+
 document.addEventListener('onIncognitoOptionsOpened', function (e)
 {
     var drop = document.getElementsByClassName("drop")[0];

--- a/core/interception.js
+++ b/core/interception.js
@@ -377,6 +377,7 @@ function exposeWhatsAppAPI()
     window.WhatsAppAPI.Seen = moduleFinder.findModule("sendSeen")[0];
     window.WhatsAppAPI.Communication = moduleFinder.findModule("getComms")[0].getComms();
     window.WhatsAppAPI.LoadEarlierMessages = moduleFinder.findModule("loadEarlierMsgs")[0];
+    window.WhatsAppAPI.sendPresenceStatusProtocol = moduleFinder.findModule("sendPresenceStatusProtocol")[0].sendPresenceStatusProtocol
 
     if (window.WhatsAppAPI.Seen == undefined)
     {

--- a/core/ui.js
+++ b/core/ui.js
@@ -476,14 +476,7 @@ function onPresenseUpdatesTick()
     {
         untickCheckbox(checkbox, checkmark);
         presenceUpdatesHook = false;
-        Swal.fire({
-            title: "Presence updates",
-            html: 'Online status won\'t work until the page is refreshed, but typing indicators will.',
-            icon: "info",
-            width: 600,
-            confirmButtonColor: "#000",
-            confirmButtonText: "Got it",
-        })
+        document.dispatchEvent(new CustomEvent('onPresenceOptionUnticked'));
     }
     browser.runtime.sendMessage({ name: "setOptions", presenceUpdatesHook: presenceUpdatesHook });
     document.dispatchEvent(new CustomEvent('onOptionsUpdate',

--- a/core/ui.js
+++ b/core/ui.js
@@ -470,11 +470,20 @@ function onPresenseUpdatesTick()
     {
         tickCheckbox(checkbox, checkmark);
         presenceUpdatesHook = true;
+        document.dispatchEvent(new CustomEvent('onPresenceOptionTicked'));
     }
     else
     {
         untickCheckbox(checkbox, checkmark);
         presenceUpdatesHook = false;
+        Swal.fire({
+            title: "Presence updates",
+            html: 'Online status won\'t work until the page is refreshed, but typing indicators will.',
+            icon: "info",
+            width: 600,
+            confirmButtonColor: "#000",
+            confirmButtonText: "Got it",
+        })
     }
     browser.runtime.sendMessage({ name: "setOptions", presenceUpdatesHook: presenceUpdatesHook });
     document.dispatchEvent(new CustomEvent('onOptionsUpdate',


### PR DESCRIPTION
Issue #155 
This sends a "unavailable" status (status as in presence status rather than the statuses that are messages sent to all contacts) when the checkbox is ticked, and alerts the user when unticked that a refresh will be required.

Note that there is currently no functionality to say "Don't ask me again" to the sweetalert popup.