### PR TITLE
Separate Hide Typing and Hide Online options

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,9 +10,13 @@ browser.runtime.onMessage.addListener(function (messageEvent, sender, callback)
 {
     if (messageEvent.name == "setOptions")
     {
-        if ("presenceUpdatesHook" in messageEvent)
+        if ("onlineUpdatesHook" in messageEvent)
 		{
-            chrome.storage.local.set({"presenceUpdatesHook": messageEvent.presenceUpdatesHook});
+            chrome.storage.local.set({"onlineUpdatesHook": messageEvent.onlineUpdatesHook});
+		}
+        if ("typingUpdatesHook" in messageEvent)
+		{
+            chrome.storage.local.set({"typingUpdatesHook": messageEvent.typingUpdatesHook});
 		}
 		if ("readConfirmationsHook" in messageEvent)
 		{
@@ -46,7 +50,8 @@ browser.runtime.onMessage.addListener(function (messageEvent, sender, callback)
     else if (messageEvent.name == "getOptions")
     {
         // these are the default values. we will update them according to the storage
-		var presenceUpdatesHook = true;
+		var onlineUpdatesHook = false;
+        var typingUpdatesHook = true;
         var readConfirmationsHook = true;
         var showReadWarning = true;
 		var safetyDelay = 0;
@@ -55,7 +60,8 @@ browser.runtime.onMessage.addListener(function (messageEvent, sender, callback)
         var autoReceiptOnReplay = true;
         var allowStatusDownload = true;
 
-        chrome.storage.local.get(['presenceUpdatesHook', 
+        chrome.storage.local.get(['onlineUpdatesHook',
+                                'typingUpdatesHook',
                                 'readConfirmationsHook', 
                                 'showReadWarning', 
                                 'safetyDelay', 
@@ -64,9 +70,13 @@ browser.runtime.onMessage.addListener(function (messageEvent, sender, callback)
                                 'autoReceiptOnReplay',
                                 'allowStatusDownload']).then(function(storage)
         {
-            if (storage["presenceUpdatesHook"] != undefined)
+            if (storage["onlineUpdatesHook"] != undefined)
             {
-                presenceUpdatesHook = storage["presenceUpdatesHook"];
+                onlineUpdatesHook = storage["onlineUpdatesHook"];
+            }
+            if (storage["typingUpdatesHook"] != undefined)
+            {
+                typingUpdatesHook = storage["typingUpdatesHook"];
             }
             if (storage["readConfirmationsHook"] != undefined)
             {
@@ -98,7 +108,8 @@ browser.runtime.onMessage.addListener(function (messageEvent, sender, callback)
             }
             callback(
             {
-                presenceUpdatesHook: presenceUpdatesHook,
+                onlineUpdatesHook: onlineUpdatesHook,
+                typingUpdatesHook: typingUpdatesHook,
                 readConfirmationsHook: readConfirmationsHook,
                 showReadWarning: showReadWarning,
                 safetyDelay: safetyDelay,

--- a/core/injected_ui.js
+++ b/core/injected_ui.js
@@ -70,7 +70,8 @@ document.addEventListener('onOptionsUpdate', function (e)
     // TODO: move outside injected_ui.js
     var options = JSON.parse(e.detail);
     if ('readConfirmationsHook' in options) readConfirmationsHookEnabled = options.readConfirmationsHook;
-    if ('presenceUpdatesHook' in options) presenceUpdatesHookEnabled = options.presenceUpdatesHook;
+    if ('onlineUpdatesHook' in options) onlineUpdatesHookEnabled = options.onlineUpdatesHook;
+    if ('typingUpdatesHook' in options) typingUpdatesHookEnabled = options.typingUpdatesHook;
     if ('safetyDelay' in options) safetyDelay = options.safetyDelay;
     if ('saveDeletedMsgs' in options) saveDeletedMsgsHookEnabled = options.saveDeletedMsgs;
     if ('showDeviceTypes' in options) showDeviceTypesEnabled = options.showDeviceTypes;

--- a/core/node_handler.js
+++ b/core/node_handler.js
@@ -47,9 +47,9 @@ NodeHandler.isSentNodeAllowed = function (node)
             (readConfirmationsHookEnabled && action == "receipt" && data["type"] === "played") ||
             (readConfirmationsHookEnabled && action == "received" && data["type"] === "played") ||
 
-            (presenceUpdatesHookEnabled && action === "presence" && data["type"] === "available") ||
-            (presenceUpdatesHookEnabled && action == "presence" && data["type"] == "composing") ||
-            (presenceUpdatesHookEnabled && action == "chatstate" && child.content[0].tag == "composing");
+            (onlineUpdatesHookEnabled && action === "presence" && data["type"] === "available") ||
+            (typingUpdatesHookEnabled && action == "presence" && data["type"] == "composing") ||
+            (typingUpdatesHookEnabled && action == "chatstate" && child.content[0].tag == "composing");
 
         if (shouldBlock)
         {

--- a/core/ui.js
+++ b/core/ui.js
@@ -219,7 +219,7 @@ function generateDropContent(options)
     var onlineStatusCaption = "Stops sending presence updates. If enabled, will prevent you from seeing others' online status.";
 
     var typingStatusTitle = "Hide \"Typing...\" status";
-    var typingStatusCaption = "Will prevent you from sending 'Typing...' status.";
+    var typingStatusCaption = "Stops sending typing updates.";
 
     var readConfirmationsTitle = "Don't send read confirmations";
     var readConfirmationsCaption = "Blocked messages will be marked with a button.";

--- a/core/ui.js
+++ b/core/ui.js
@@ -215,8 +215,16 @@ async function addIconIfNeeded()
 
 function generateDropContent(options)
 {
-    var onlineStatusCaption = "Will prevent you from being online. If you enable this, you won't be able to see others' status.";
+    var onlineStatusTitle = "Hide \"Online\" status";
+    var onlineStatusCaption = "Stops sending presence updates. If enabled, will prevent you from seeing others' online status.";
+
+    var typingStatusTitle = "Hide \"Typing...\" status";
     var typingStatusCaption = "Will prevent you from sending 'Typing...' status.";
+
+    var readConfirmationsTitle = "Don't send read confirmations";
+    var readConfirmationsCaption = "Blocked messages will be marked with a button.";
+    var readConfirmationsNote = "Also works for stories and audio messages.";
+
     var deletedMessagesTitle = "Restore deleted messages";
     var deletedMessagesCaption = "Marks deleted messages in red";
 
@@ -266,11 +274,11 @@ function generateDropContent(options)
                             <div class='checkbox checkbox-incognito ${readConfirmationCheckbox}
                             </div>
                         </div>
-                        Don't send read confirmations
-                        <div class='incognito-options-description'>Blocked messages will be marked with a button.</div>
+                        ${readConfirmationsTitle}
+                        <div class='incognito-options-description'>${readConfirmationsCaption}</div>
                         <br>
                         <div style='margin-left: 28px !important; margin-top: 0px; font-size: 12px; opacity: 0.8'>
-                            Also works for stories and audio messages.
+                            ${readConfirmationsNote}
                         </div> 
                     </div> 
                             
@@ -279,7 +287,7 @@ function generateDropContent(options)
                             <div class='checkbox checkbox checkbox-incognito ${onlineUpdatesCheckbox}
                             </div>
                         </div>
-                        Hide \"Online\" status
+                        ${onlineStatusTitle}
                         <div class='incognito-options-description'>${onlineStatusCaption}</div>
                     </div>
                     <div id='incognito-option-typing-status' class='incognito-options-item' style='cursor: pointer;'>
@@ -287,7 +295,7 @@ function generateDropContent(options)
                             <div class='checkbox checkbox checkbox-incognito ${typingUpdatesCheckbox}
                             </div>
                         </div>
-                        Hide \"Typing...\" status
+                        ${typingStatusTitle}
                         <div class='incognito-options-description'>${typingStatusCaption}</div>
                     </div>
                     <button class='incognito-next-button'>Next &gt</button>

--- a/core/ui.js
+++ b/core/ui.js
@@ -322,6 +322,7 @@ function generateDropContent(options)
                             ${autoReceiptTitle}
                             <div class='incognito-options-description'>${autoReceiptCaption}</div>
                         </div>
+                        <br>
                         <button class='incognito-next-button'>Next &gt</button>
                         <button class='incognito-back-button'>&lt Back</button>
                     </div>

--- a/core/ui.js
+++ b/core/ui.js
@@ -154,7 +154,8 @@ async function addIconIfNeeded()
                 document.getElementsByClassName("menu-item-incognito")[0].setAttribute("class", pressedMenuItemClass);
 
                 document.getElementById("incognito-option-read-confirmations").addEventListener("click", onReadConfirmaionsTick);
-                document.getElementById("incognito-option-presence-updates").addEventListener("click", onPresenseUpdatesTick);
+                document.getElementById("incognito-option-online-status").addEventListener("click", onOnlineUpdatesTick);
+                document.getElementById("incognito-option-typing-status").addEventListener("click", onTypingUpdatesTick);
                 document.getElementById("incognito-option-save-deleted-msgs").addEventListener("click", onSaveDeletedMsgsTick);
                 document.getElementById("incognito-option-show-device-type").addEventListener("click", onShowDeviceTypesTick);
                 document.getElementById("incognito-option-auto-receipt").addEventListener("click", onAutoReceiptsTick);
@@ -180,7 +181,8 @@ async function addIconIfNeeded()
                 document.getElementsByClassName("menu-item-incognito")[0].setAttribute("class", UIClassNames.MENU_ITEM_CLASS + " menu-item-incognito");
 
                 document.getElementById("incognito-option-read-confirmations").removeEventListener("click", onReadConfirmaionsTick);
-                document.getElementById("incognito-option-presence-updates").removeEventListener("click", onPresenseUpdatesTick);
+                document.getElementById("incognito-option-online-status").removeEventListener("click", onOnlineUpdatesTick);
+                document.getElementById("incognito-option-typing-status").removeEventListener("click", onTypingUpdatesTick);
 
                 for (var nextButton of document.getElementsByClassName('incognito-next-button'))
                 {
@@ -213,7 +215,8 @@ async function addIconIfNeeded()
 
 function generateDropContent(options)
 {
-    var presenceCaption = "Will prevent you from seeing other people's last seen and typing status";
+    var onlineStatusCaption = "Will prevent you from being online. If you enable this, you won't be able to see others' status.";
+    var typingStatusCaption = "Will prevent you from sending 'Typing...' status.";
     var deletedMessagesTitle = "Restore deleted messages";
     var deletedMessagesCaption = "Marks deleted messages in red";
 
@@ -229,7 +232,10 @@ function generateDropContent(options)
     var readConfirmationCheckbox = (options.readConfirmationsHook ? "checked incognito-checked'> \
         <div class='checkmark incognito-mark incognito-marked'> </div>" :
         "unchecked " + "'> <div class='checkmark incognito-mark" + "'> </div>");
-    var presenceUpdatesChcekbox = (options.presenceUpdatesHook ? "checked incognito-checked'> \
+    var onlineUpdatesCheckbox = (options.onlineUpdatesHook ? "checked incognito-checked'> \
+        <div class='checkmark incognito-mark incognito-marked'> </div>" :
+        "unchecked " + "'> <div class='checkmark incognito-mark" + "'> </div>");
+    var typingUpdatesCheckbox = (options.typingUpdatesHook ? "checked incognito-checked'> \
         <div class='checkmark incognito-mark incognito-marked'> </div>" :
         "unchecked " + "'> <div class='checkmark incognito-mark" + "'> </div>");
     var saveDeletedMessagesCheckbox = (options.saveDeletedMsgs ? "checked incognito-checked'> \
@@ -268,21 +274,21 @@ function generateDropContent(options)
                         </div> 
                     </div> 
                             
-                    <div id='incognito-option-presence-updates' class='incognito-options-item' style='cursor: pointer;'>
+                    <div id='incognito-option-online-status' class='incognito-options-item' style='cursor: pointer;'>
                         <div class='checkbox-container-incognito' style=''>
-                            <div class='checkbox checkbox checkbox-incognito ${presenceUpdatesChcekbox}
+                            <div class='checkbox checkbox checkbox-incognito ${onlineUpdatesCheckbox}
                             </div>
                         </div>
-                        Don't send \"Last Seen\" and \"Typing\" updates
-                        <div class='incognito-options-description'>${presenceCaption}</div>
+                        Hide \"Online\" status
+                        <div class='incognito-options-description'>${onlineStatusCaption}</div>
                     </div>
-                    <div id='incognito-option-save-deleted-msgs' class='incognito-options-item' style='cursor: pointer;'>
+                    <div id='incognito-option-typing-status' class='incognito-options-item' style='cursor: pointer;'>
                         <div class='checkbox-container-incognito' style=''>
-                            <div class='checkbox checkbox checkbox-incognito ${saveDeletedMessagesCheckbox}
+                            <div class='checkbox checkbox checkbox-incognito ${typingUpdatesCheckbox}
                             </div>
                         </div>
-                        ${deletedMessagesTitle}
-                        <div class='incognito-options-description'>${deletedMessagesCaption}</div>
+                        Hide \"Typing...\" status
+                        <div class='incognito-options-description'>${typingStatusCaption}</div>
                     </div>
                     <button class='incognito-next-button'>Next &gt</button>
                 </div>
@@ -290,8 +296,16 @@ function generateDropContent(options)
                 <div class='incognito-options-view-container'  style='transform: translate(100%, 0%);' id='incognito-options-view2'>
 
                     <!---- Second Page ---!>
-
+                    
                     <div class='incognito-options-view' id='incognito-options-view-internal2'>
+                        <div id='incognito-option-save-deleted-msgs' class='incognito-options-item' style='cursor: pointer;'>
+                            <div class='checkbox-container-incognito' style=''>
+                                <div class='checkbox checkbox checkbox-incognito ${saveDeletedMessagesCheckbox}
+                                </div>
+                            </div>
+                            ${deletedMessagesTitle}
+                            <div class='incognito-options-description'>${deletedMessagesCaption}</div>
+                        </div>
                         <div id='incognito-option-show-device-type' class='incognito-options-item' style='cursor: pointer;'>
                             <div class='checkbox-container-incognito' style=''>
                                 <div class='checkbox checkbox checkbox-incognito ${showDeviceTypeCheckbox}
@@ -308,15 +322,6 @@ function generateDropContent(options)
                             ${autoReceiptTitle}
                             <div class='incognito-options-description'>${autoReceiptCaption}</div>
                         </div>
-                        <div id='incognito-option-status-downloading' class='incognito-options-item' style='cursor: pointer;'>
-                            <div class='checkbox-container-incognito' style=''>
-                                <div class='checkbox checkbox checkbox-incognito ${allowStatusDownloadCheckbox}
-                                </div>
-                            </div>
-                            ${allowStatusDownloadTitle}
-                            <div class='incognito-options-description'>${allowStatusDownloadCaption}</div>
-                        </div>
-                        <br>
                         <button class='incognito-next-button'>Next &gt</button>
                         <button class='incognito-back-button'>&lt Back</button>
                     </div>
@@ -325,8 +330,15 @@ function generateDropContent(options)
                 <div class='incognito-options-view-container' style='transform: translate(200%, 0%);' id='incognito-options-view3'>
 
                     <!---- Third Page ---!>
-
                     <div class='incognito-options-view' id='incognito-options-view-internal3'>
+                        <div id='incognito-option-status-downloading' class='incognito-options-item' style='cursor: pointer;'>
+                            <div class='checkbox-container-incognito' style=''>
+                                <div class='checkbox checkbox checkbox-incognito ${allowStatusDownloadCheckbox}
+                                </div>
+                            </div>
+                            ${allowStatusDownloadTitle}
+                            <div class='incognito-options-description'>${allowStatusDownloadCaption}</div>
+                        </div>
                         <div class='incognito-options-item' style='cursor: pointer;'>
                             More options coming soon!
                         </div>
@@ -459,29 +471,53 @@ function onReadConfirmaionsTick()
     }));
 }
 
-function onPresenseUpdatesTick()
+function onOnlineUpdatesTick()
 {
-    var presenceUpdatesHook = false;
-    var checkbox = document.querySelector("#incognito-option-presence-updates .checkbox-incognito");
+    var onlineUpdatesHook = false;
+    var checkbox = document.querySelector("#incognito-option-online-status .checkbox-incognito");
     var checkboxClass = checkbox.getAttribute("class");
     var checkmark = checkbox.firstElementChild;
     var chekmarkClass = checkmark.getAttribute("class");
     if (checkboxClass.indexOf("unchecked") > -1)
     {
         tickCheckbox(checkbox, checkmark);
-        presenceUpdatesHook = true;
+        onlineUpdatesHook = true;
         document.dispatchEvent(new CustomEvent('onPresenceOptionTicked'));
     }
     else
     {
         untickCheckbox(checkbox, checkmark);
-        presenceUpdatesHook = false;
+        onlineUpdatesHook = false;
         document.dispatchEvent(new CustomEvent('onPresenceOptionUnticked'));
     }
-    browser.runtime.sendMessage({ name: "setOptions", presenceUpdatesHook: presenceUpdatesHook });
+    browser.runtime.sendMessage({ name: "setOptions", onlineUpdatesHook: onlineUpdatesHook });
     document.dispatchEvent(new CustomEvent('onOptionsUpdate',
     {
-        detail: JSON.stringify({ presenceUpdatesHook: presenceUpdatesHook })
+        detail: JSON.stringify({ onlineUpdatesHook: onlineUpdatesHook })
+    }));
+}
+
+function onTypingUpdatesTick()
+{
+    var typingUpdatesHook = false;
+    var checkbox = document.querySelector("#incognito-option-typing-status .checkbox-incognito");
+    var checkboxClass = checkbox.getAttribute("class");
+    var checkmark = checkbox.firstElementChild;
+    var chekmarkClass = checkmark.getAttribute("class");
+    if (checkboxClass.indexOf("unchecked") > -1)
+    {
+        tickCheckbox(checkbox, checkmark);
+        typingUpdatesHook = true;
+    }
+    else
+    {
+        untickCheckbox(checkbox, checkmark);
+        typingUpdatesHook = false;
+    }
+    browser.runtime.sendMessage({ name: "setOptions", typingUpdatesHook: typingUpdatesHook });
+    document.dispatchEvent(new CustomEvent('onOptionsUpdate',
+    {
+        detail: JSON.stringify({ typingUpdatesHook: typingUpdatesHook })
     }));
 }
 


### PR DESCRIPTION
When hiding the Online status, you won't get any updates from WhatsApp, so, if you want to hide just the 'Typing...' status, you will also hide all the online and last seen statuses from your contacts.

This separates the two options, making you able to hide the typing status but remaining online.

I tested it and it seemed to work. Feel free to test it and let me know any issues :)