### PR TITLE
Fix incognito icon alignment in sidebar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,17 @@
-
 /*
   Menu/Icon
 */
 
 .menu-item-incognito
 {
-    /*
-     cursor: pointer !important;
-    padding: 8px;
-    height: auto !important;
-    */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+}
+
+.menu-item-incognito svg {
+  margin: auto;
 }
 
 .icon-incognito


### PR DESCRIPTION
I could not help but notice a slight misalignment of the incognito logo in the menu bar.

Before:
![image](https://github.com/user-attachments/assets/f2bbb6d1-7602-468a-875e-f8c0bed2bede)
After:
![image](https://github.com/user-attachments/assets/607e1516-3f69-4f70-a7d7-a56880e9723e)

I know this is a minimal change,Thanks for considering!
