### PR TITLE
Convert to Safari (macOS & iOS) Extension

### DIFF
--- a/.github/workflows/convert-to-safari.yml
+++ b/.github/workflows/convert-to-safari.yml
@@ -1,0 +1,50 @@
+# Name of the workflow, displayed in the GitHub Actions tab.
+name: Convert to Safari (macOS & iOS) Extension
+
+# Defines the triggers for this workflow.
+on:
+  # Runs on every push to the 'master' branch.
+  push:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  convert-to-safari-extension:
+    # Specifies the runner environment. macOS is required for 'xcrun'.
+    runs-on: macos-latest
+
+    # Contains the sequence of steps for this job.
+    steps:
+      # Step 1: Check out the repository's code so the runner can access it.
+      - name: Check out the repository code
+        uses: actions/checkout@v4
+
+      # Step 2: Run the core conversion command.
+      - name: Convert Chrome Extension to Safari/iOS
+        run: |
+          # Move WAIncognito sources to separate folder
+          mkdir extension-source
+          shopt -s extglob
+          mv !(extension-source|.github) extension-source/
+          echo "Source files moved into ./extension-source"
+
+          # Execute Apple's web extension converter tool
+          xcrun safari-web-extension-converter \
+            --project-location ./safari-extension-build \
+            --no-open \
+            --no-prompt \
+            ./extension-source
+          echo "Safari Extension created in ./safari-extension-build"
+
+      # Step 3: Upload the output as a build artifact.
+      - name: Upload the generated Xcode project
+        uses: actions/upload-artifact@v4
+        with:
+          # The name of the artifact file that will be available for download.
+          name: WAIncognito-Safari-Extension
+          # The paths to the folders to upload.
+          path: |
+            ./safari-extension-build
+            ./extension-source


### PR DESCRIPTION
Hi,

I found a quite simple solution that basically doesn't require any changes to the code in the repository.

Apple offers a tool that allows you to convert existing browser extensions into Safari extensions:
https://developer.apple.com/documentation/safariservices/packaging-a-web-extension-for-safari

I’ve used it on the WAIncognito sources and it worked out of the box. 🙂

I've then created a GitHub action script that automatically creates the Safari extension project files every time there is a push to the main branch and uploads it as an artifact.

<img width="1285" height="691" alt="image" src="https://github.com/user-attachments/assets/3dbbfa07-e136-44e0-b559-3ae7a2a9c2a6" />


You can download the created zip file, open the containing project in Xcode and build it.

<img width="1053" height="683" alt="image" src="https://github.com/user-attachments/assets/d9b5eddb-ff5a-4b5b-b2e7-114dace0d2ce" />


This was the first GitHub action script I’ve created with the help of AI, so if you find things to optimize feel free to adjust it. 

I've tested the Safari extension on a Mac and an iPhone, and it worked fine on both devices.
On the iPhone, I had to adjust the browser’s user agent so that the WhatsApp Web page loaded correctly. I did this using the [Unagent extension](https://github.com/katagaki/Unagent).

If you need any more information, e.g. on how to build the extension with Xcode or on anything else, I can add this up, but I first wanted to clarify if this is wanted at all. 😉