### PR TITLE
 Allow "played" receipts for voice messages when chat is not blocked (issue #216)

### DIFF
--- a/core/node_handler.js
+++ b/core/node_handler.js
@@ -30,12 +30,15 @@ NodeHandler.isSentNodeAllowed = function (node)
 {
     var action = node.tag;
     var data = node.attrs;
+
+    var jid = data.jid ? data.jid : data.to;
+    if (jid) jid = normalizeJID(jid.toString());
+
     var shouldBlock = 
         (readConfirmationsHookEnabled && action === "read") ||
         (readConfirmationsHookEnabled && action == "receipt" && data["type"] == "read") ||
         (readConfirmationsHookEnabled && action == "receipt" && data["type"] == "read-self") ||
-        (readConfirmationsHookEnabled && action == "receipt" && data["type"] === "played") ||
-        (readConfirmationsHookEnabled && action == "received" && data["type"] === "played") ||
+        (readConfirmationsHookEnabled && action == "receipt" && data["type"] === "played" && isChatBlocked(jid)) ||
 
         (onlineUpdatesHookEnabled && action === "presence" && data["type"] === "available") ||
         (typingUpdatesHookEnabled && action == "presence" && data["type"] == "composing") ||
@@ -47,8 +50,6 @@ NodeHandler.isSentNodeAllowed = function (node)
         {
             case "read":
             case "receipt":
-                var jid = data.jid ? data.jid : data.to;
-                jid = normalizeJID(jid.toString());
 
                 var isReadReceiptAllowed = exceptionsList.includes(jid);
                 if (isReadReceiptAllowed)


### PR DESCRIPTION
# Fix: Allow "played" receipts for voice messages when chat is not blocked (issue #216)

## Description
This PR adds support for voice message "played" receipts while maintaining privacy when read receipts are disabled.

### Problem
Previously, when clicking the "Mark as Read" button, only "read" receipts were sent, but "played" receipts for voice messages were still blocked by the extension. This caused voice messages to show as read (blue checkmarks), but not as played (blue microphone icon), creating an inconsistent state.

### Changes
- Modified `NodeHandler.isSentNodeAllowed()` to allow `receipt` nodes with `type="played"` only when the chat is not blocked
- Removed `received` action with `type="played"` from the blocking logic (I think this was redundant)
- "played" receipts are now treated similarly to "read" receipts: they are blocked by default and only sent when the user clicked the "Mark as Read" button before playing them

### Behavior
- ✅ When a chat has no blocked messages: "played" receipts are sent normally, showing the blue microphone icon
- ❌ When a chat has blocked messages: "played" receipts are blocked until the user sends a manual confirmation
- ✅ When the "Mark as Read" button is clicked: "read" receipts are sent immediately (like before), and "played" receipts are sent when the user plays a voice message after clicking the button

### Limitations
Unfortunately, a perfect solution for preventing the local UI status change (blue microphone icon appearing locally) while the chat is blocked has not yet been found. When a user plays a voice message in a blocked chat:
- The message is marked as "played" locally in the UI
- Subsequent plays don't trigger new receipts (since WhatsApp sees it as already played)
- A page reload resets the status, allowing the receipt to be sent on the next play
